### PR TITLE
Symfony 2.8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "php": ">=5.6",
         "monolog/monolog": "^1.23",
         "rollbar/rollbar": "^1.3",
-        "symfony/dependency-injection": "~3.0|~4.0",
-        "symfony/config": "~3.0|~4.0",
-        "symfony/http-kernel": "~3.0|~4.0"
+        "symfony/dependency-injection": "^2.8|~3.0|~4.0",
+        "symfony/config": "^2.8|~3.0|~4.0",
+        "symfony/http-kernel": "^2.8|~3.0|~4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7 || ^6.5",


### PR DESCRIPTION
The bundle works properly with Symfony 2.8, needs only minor changes in `composer.json`
 It's still long term support version. I guess that many more users will use this bundle in their Symfony 2 projects.

Travis tests fails because of `ROLLBAR_ACCESS_TOKEN` env variable being not set.