### PR TITLE
Allow excluding exceptions by interface

### DIFF
--- a/Provider/RollbarHandler.php
+++ b/Provider/RollbarHandler.php
@@ -137,7 +137,7 @@ class RollbarHandler extends AbstractProcessingHandler
     {
         // check exception
         foreach ($this->exclude as $instance) {
-            if (class_exists($instance) && $exception instanceof $instance) {
+            if ((class_exists($instance) || interface_exists($instance)) && $exception instanceof $instance) {
                 return true;
             }
         }


### PR DESCRIPTION
Allow excluding exceptions by interface.

f.e you can exclude `Symfony\Component\HttpKernel\Exception\HttpExceptionInterface` to skip capturing HTTP related exceptions.