### PR TITLE
Fix Rollbar JS integration that wasn't functional

### DIFF
--- a/Twig/RollbarExtension.php
+++ b/Twig/RollbarExtension.php
@@ -48,7 +48,9 @@ class RollbarExtension extends \Twig_Extension
         }
 
         return [
-            new \Twig_SimpleFunction('rollbarJs', [$this, 'rollbarJs']),
+            new \Twig_SimpleFunction('rollbarJs', [$this, 'rollbarJs'], [
+                'is_safe' => ['html'],
+            ]),
         ];
     }
 
@@ -59,7 +61,7 @@ class RollbarExtension extends \Twig_Extension
     {
         $helper = new RollbarJsHelper($this->config['rollbar_js']);
 
-        $script = "<script>var _rollbarConfig = {{config}};\n{{rollbar-snippet}}</script>";
+        $script = "<script>{{config}};\n{{rollbar-snippet}}</script>";
         $script = strtr($script, [
             '{{config}}'          => $helper->configJsTag(),
             '{{rollbar-snippet}}' => $helper->jsSnippet(),


### PR DESCRIPTION
- The `var _rollbarConfig = ` part of the script was doubled.
- Set the Twig function to be safe for html so that the `|raw` filter isn't required.