### PR TITLE
use twig.extension tag instead of twig.runtime

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -40,4 +40,4 @@ services:
     class: "%symfony_rollbar.twig.extension.class%"
     arguments: ["@service_container"]
     tags:
-      - { name: twig.runtime }
+      - { name: twig.extension }


### PR DESCRIPTION
On Symfony 3.4.11, I the `twig.runtime` tag doesn't seem to load the extension. I'm not sure who is at fault, but changing to the `twig.extension` tag resolves the issue completely.

The purpose of the `twig.runtime` tag is to make the extension lazy to minimize the overhead of loading all injected services for when initializing Twig. In this case the container is getting injected anyway so there really is no performance gain at all.

BTW, thanks for the fast turn-around yesterday! That was amazing! 👏 