### PR TITLE
[Dependency Injection] Add alias for rollbar handler

### DIFF
--- a/DependencyInjection/SymfonyRollbarExtension.php
+++ b/DependencyInjection/SymfonyRollbarExtension.php
@@ -3,6 +3,7 @@
 namespace SymfonyRollbarBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Alias;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -38,6 +39,11 @@ class SymfonyRollbarExtension extends Extension
 
         // store parameters for external use
         $container->setParameter(static::ALIAS . '.config', $config);
+
+        $container->setAlias(
+            $container->getParameter('symfony_rollbar.provider.rollbar_handler.class'),
+            new Alias('symfony_rollbar.provider.rollbar_handler', false)
+        );
     }
 
     /**


### PR DESCRIPTION
I have symfony 3.4 and the latest version of symfony-rollbar-bundle
When I open profiler I see deprecation warning:

> Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "symfony_rollbar.provider.rollbar_handler" service to "SymfonyRollbarBundle\Provider\RollbarHandler" instead.

Commit will fix this deprecation. Could you please review it?